### PR TITLE
Fix compilation on ESP-IDF 5.3.1, platform 6.9.0

### DIFF
--- a/components/daikin_s21/climate/daikin_s21_climate.cpp
+++ b/components/daikin_s21/climate/daikin_s21_climate.cpp
@@ -1,3 +1,4 @@
+#include <cinttypes>
 #include "esphome/core/defines.h"
 #include "esphome/core/hal.h"
 #include "esphome/core/log.h"
@@ -24,7 +25,7 @@ void DaikinS21Climate::setup() {
 
 void DaikinS21Climate::dump_config() {
   ESP_LOGCONFIG(TAG, "DaikinS21Climate:");
-  ESP_LOGCONFIG(TAG, "  Update interval: %u", this->get_update_interval());
+  ESP_LOGCONFIG(TAG, "  Update interval: %" PRIu32, this->get_update_interval());
   if (this->room_sensor_ != nullptr) {
     if (!this->room_sensor_unit_is_valid()) {
       ESP_LOGCONFIG(TAG, "  ROOM SENSOR: INVALID UNIT '%s' (must be °C or °F)",
@@ -139,6 +140,8 @@ void DaikinS21Climate::save_setpoint(float value) {
       case DaikinClimateMode::Heat:
         this->save_setpoint(value, this->heat_setpoint_pref);
         break;
+      default:
+        break;
     }
   }
 }
@@ -162,6 +165,8 @@ optional<float> DaikinS21Climate::load_setpoint(DaikinClimateMode mode) {
       break;
     case DaikinClimateMode::Heat:
       loaded = this->load_setpoint(this->heat_setpoint_pref);
+      break;
+    default:
       break;
   }
   return loaded;

--- a/components/daikin_s21/s21.cpp
+++ b/components/daikin_s21/s21.cpp
@@ -1,3 +1,4 @@
+#include <cinttypes>
 #include "s21.h"
 
 using namespace esphome;
@@ -105,7 +106,7 @@ void DaikinS21::check_uart_settings() {
       ESP_LOGE(
           TAG,
           "  Invalid baud_rate: Integration requested baud_rate %u but you "
-          "have %u!",
+          "have %" PRIu32 "!",
           S21_BAUD_RATE, uart->get_baud_rate());
     }
     if (uart->get_stop_bits() != S21_STOP_BITS) {
@@ -133,7 +134,7 @@ void DaikinS21::check_uart_settings() {
 
 void DaikinS21::dump_config() {
   ESP_LOGCONFIG(TAG, "DaikinS21:");
-  ESP_LOGCONFIG(TAG, "  Update interval: %u", this->get_update_interval());
+  ESP_LOGCONFIG(TAG, "  Update interval: %" PRIu32, this->get_update_interval());
   this->check_uart_settings();
 }
 


### PR DESCRIPTION
I'm using a newer toolchain for ESP32 S3 support and ran into these minor issues the compiler didn't like:
* Use cinttypes defines to resolve printf formatting errors
* Add default nop() cases to a couple switch statements

There's still an issue with climate::climate_mode_to_string's return type, but these other changes should be benign.