### PR TITLE
Fix target temperature responce

### DIFF
--- a/components/daikin_s21/climate/daikin_s21_climate.cpp
+++ b/components/daikin_s21/climate/daikin_s21_climate.cpp
@@ -153,7 +153,7 @@ optional<float> DaikinS21Climate::load_setpoint(ESPPreferenceObject &pref) {
 
 optional<float> DaikinS21Climate::load_setpoint(DaikinClimateMode mode) {
   optional<float> loaded;
-  switch (this->s21->get_climate_mode()) {
+  switch (mode) {
     case DaikinClimateMode::Auto:
       loaded = this->load_setpoint(this->auto_setpoint_pref);
       break;

--- a/components/daikin_s21/climate/daikin_s21_climate.cpp
+++ b/components/daikin_s21/climate/daikin_s21_climate.cpp
@@ -125,7 +125,7 @@ void DaikinS21Climate::save_setpoint(float value, ESPPreferenceObject &pref) {
 }
 
 void DaikinS21Climate::save_setpoint(float value) {
-  auto mode = this->s21->get_climate_mode();
+  auto mode = this->e2d_climate_mode(this->mode);
   optional<float> prev = this->load_setpoint(mode);
   // Only save if value is diff from what's already saved.
   if (abs(value - prev.value_or(0.0)) >= SETPOINT_STEP) {

--- a/components/daikin_s21/climate/daikin_s21_climate.cpp
+++ b/components/daikin_s21/climate/daikin_s21_climate.cpp
@@ -333,7 +333,7 @@ void DaikinS21Climate::update() {
       // the target temperature here if it appears uninitialized.
       float current_s21_sp = this->s21->get_setpoint();
       float unexpected_diff = abs(this->expected_s21_setpoint - current_s21_sp);
-      if (this->target_temperature == 0.0) {
+      if (this->target_temperature == 0.0 || isnanf(this->target_temperature)) {
         // Use stored setpoint for mode, or fall back to use s21's setpoint.
         auto stored = this->load_setpoint(this->s21->get_climate_mode());
         this->target_temperature = stored.value_or(current_s21_sp);


### PR DESCRIPTION
First thank you for the great esphome component!

I have the odd behavior that the target temperature is NaN after esphome restarting and the daikin is in off mode. Switching then to e.g. heating mode does not send a target temperature, it is still NaN. Switching back to OFF will sends a target temperature of 21℃. After that, I can used Home Assistant to set a target temperature.

This pull request fixes that behavior. There was an obvious bug, not using the function parameter in `load_setpoint()`.
Also, my Daikin model (F28KTNS-W) does not seem to respond with the correct mode after setting. So it is better to use the mode from the esphome `Climate` class to save the setpoint in `save_setpoint()`.

