### PR TITLE
Add serial command state machine to prevent blocking esphome main loop

### DIFF
--- a/components/daikin_s21/__init__.py
+++ b/components/daikin_s21/__init__.py
@@ -41,5 +41,5 @@ async def to_code(config):
     await cg.register_component(var, config)
     tx_uart = await cg.get_variable(config[CONF_TX_UART])
     rx_uart = await cg.get_variable(config[CONF_RX_UART])
-    cg.add(var.set_uarts(tx_uart, rx_uart))
+    cg.add(var.serial.set_uarts(tx_uart, rx_uart))
     cg.add(var.set_debug_protocol(config[CONF_DEBUG_PROTOCOL]))

--- a/components/daikin_s21/climate/daikin_s21_climate.cpp
+++ b/components/daikin_s21/climate/daikin_s21_climate.cpp
@@ -10,7 +10,7 @@ using namespace esphome;
 namespace esphome {
 namespace daikin_s21 {
 
-#define SETPOINT_MIN 18
+#define SETPOINT_MIN 10
 #define SETPOINT_MAX 32
 #define SETPOINT_STEP 0.5f
 
@@ -416,7 +416,7 @@ void DaikinS21Climate::set_s21_climate() {
   this->expected_s21_setpoint =
       this->calc_s21_setpoint(this->target_temperature);
   ESP_LOGI(TAG, "Controlling S21 climate:");
-  ESP_LOGI(TAG, "  Mode: %s", climate::climate_mode_to_string(this->mode));
+  ESP_LOGI(TAG, "  Mode: %s", LOG_STR_ARG(climate::climate_mode_to_string(this->mode)));
   ESP_LOGI(TAG, "  Setpoint: %.1f (s21: %.1f)", this->target_temperature,
            this->expected_s21_setpoint);
   ESP_LOGI(TAG, "  Fan: %s", this->custom_fan_mode.value().c_str());

--- a/components/daikin_s21/s21.h
+++ b/components/daikin_s21/s21.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <bitset>
+#include <vector>
 #include "esphome/components/uart/uart.h"
 #include "esphome/core/component.h"
 
@@ -31,56 +33,105 @@ std::string daikin_fan_mode_to_string(DaikinFanMode mode);
 inline float c10_c(int16_t c10) { return c10 / 10.0; }
 inline float c10_f(int16_t c10) { return c10_c(c10) * 1.8 + 32.0; }
 
-class DaikinS21 : public PollingComponent {
- public:
-  void update() override;
-  void dump_config() override;
-  void set_uarts(uart::UARTComponent *tx, uart::UARTComponent *rx);
-  void set_debug_protocol(bool set) { this->debug_protocol = set; }
-  bool is_ready() { return this->ready; }
-
-  bool is_power_on() { return this->power_on; }
-  DaikinClimateMode get_climate_mode() { return this->mode; }
-  DaikinFanMode get_fan_mode() { return this->fan; }
-  float get_setpoint() { return this->setpoint / 10.0; }
-  void set_daikin_climate_settings(bool power_on, DaikinClimateMode mode,
-                                   float setpoint, DaikinFanMode fan_mode);
-  void set_swing_settings(bool swing_v, bool swing_h);
-  bool send_cmd(std::vector<uint8_t> code, std::vector<uint8_t> payload);
-
-  float get_temp_inside() { return this->temp_inside / 10.0; }
-  float get_temp_outside() { return this->temp_outside / 10.0; }
-  float get_temp_coil() { return this->temp_coil / 10.0; }
-  uint16_t get_fan_rpm() { return this->fan_rpm; }
-  bool is_idle() { return this->idle; }
-  bool get_swing_h() { return this->swing_h; }
-  bool get_swing_v() { return this->swing_v; }
-
- protected:
-  bool read_frame(std::vector<uint8_t> &payload);
-  void write_frame(std::vector<uint8_t> payload);
-  bool s21_query(std::vector<uint8_t> code);
-  bool parse_response(std::vector<uint8_t> rcode, std::vector<uint8_t> payload);
-  bool run_queries(std::vector<std::string> queries);
-  void dump_state();
-  void check_uart_settings();
-
-  uart::UARTComponent *tx_uart{nullptr};
-  uart::UARTComponent *rx_uart{nullptr};
-  bool ready = false;
-  bool debug_protocol = false;
-
+struct DaikinSettings {
   bool power_on = false;
   DaikinClimateMode mode = DaikinClimateMode::Disabled;
   DaikinFanMode fan = DaikinFanMode::Auto;
   int16_t setpoint = 23;
   bool swing_v = false;
   bool swing_h = false;
+};
+
+class DaikinS21 : public PollingComponent {
+ public:
+  void setup() override;
+  void loop() override;
+  void update() override;
+  void dump_config() override;
+  void set_uarts(uart::UARTComponent *tx, uart::UARTComponent *rx);
+  void set_debug_protocol(bool set) { this->debug_protocol = set; }
+
+  bool is_ready() { return this->ready.all(); }
+
+  bool is_power_on() { return this->active.power_on; }
+  DaikinClimateMode get_climate_mode() { return this->active.mode; }
+  DaikinFanMode get_fan_mode() { return this->active.fan; }
+  float get_setpoint() { return this->active.setpoint / 10.0; }
+  bool get_swing_h() { return this->active.swing_h; }
+  bool get_swing_v() { return this->active.swing_v; }
+
+  // external command actions
+  void set_daikin_climate_settings(bool power_on, DaikinClimateMode mode,
+                                   float setpoint, DaikinFanMode fan_mode);
+  void set_swing_settings(bool swing_v, bool swing_h);
+
+  float get_temp_inside() { return this->temp_inside / 10.0; }
+  float get_temp_outside() { return this->temp_outside / 10.0; }
+  float get_temp_coil() { return this->temp_coil / 10.0; }
+  uint16_t get_fan_rpm() { return this->fan_rpm; }
+  uint8_t get_swing_vertical_angle() { return this->swing_vertical_angle; }
+  uint16_t get_compressor_frequency() { return this->compressor_hz; }
+  bool is_idle() { return this->compressor_hz == 0; }
+
+ protected:
+  static constexpr uint32_t S21_RESPONSE_TURNAROUND = 75; // allow some time for the unit to begin listening after it sends
+  static constexpr uint32_t S21_RESPONSE_TIMEOUT = 250; // character timeout when expecting a response from the unit
+  static constexpr uint32_t S21_ERROR_TIMEOUT = 3000; // cooldown time when something goes wrong
+  static constexpr uint32_t S21_MAX_COMMAND_SIZE = 4;
+  static constexpr uint32_t S21_MAX_PAYLOAD_SIZE = 4;
+
+  void dump_state();
+  void check_uart_settings();
+  void write_frame(const uint8_t *payload = nullptr, size_t payload_len = 0);
+  void tx_next_command();
+  void parse_command_response();
+  void handle_rx_byte(uint8_t new_byte);
+
+  uart::UARTComponent *tx_uart{nullptr};
+  uart::UARTComponent *rx_uart{nullptr};
+
+  // communication state machine
+  enum class CommState : uint8_t {
+    Idle,
+    QueryAck,
+    QueryStx,
+    QueryEtx,
+    CommandAck,
+    Error
+  };
+  CommState comm_state = CommState::Idle;
+  enum RequiredCommand : uint8_t {
+    ReadyBasic,
+    ReadySwing,
+    ReadyCompressor,
+    ReadyCount, // just for bitset sizing
+  };
+  std::bitset<ReadyCount> ready = {};
+  std::vector<const char *> queries = {};
+  std::vector<const char *>::iterator current_query;
+  const char *tx_command = "";  // used when matching responses - value must have persistent lifetime
+  std::vector<uint8_t> rx_buffer = {};
+  uint32_t rx_timeout = 0;
+  bool refresh_state = false;
+  bool debug_protocol = false;
+  std::unordered_map<std::string, std::vector<uint8_t>> val_cache;  // debugging
+
+  // settings
+  DaikinSettings active = {};
+  DaikinSettings pending = {};
+  bool activate_climate = false;
+  bool activate_swing_mode = false;
+
+  // current values
   int16_t temp_inside = 0;
   int16_t temp_outside = 0;
   int16_t temp_coil = 0;
   uint16_t fan_rpm = 0;
-  bool idle = true;
+  int16_t swing_vertical_angle = 0;
+  uint8_t compressor_hz = 0;
+
+  //protocol support
+  bool support_rg = false;
 };
 
 class DaikinS21Client {


### PR DESCRIPTION
- setup() initializes a pool of commands/queries to be periodically run
- loop() transmits each command/query and waits for the response, yielding control if it's not ready
- Changes to settings must be staged and applied asynchronously
- All of this requires much more saved state in the DaikinS21 object

Other changes:
- Add ETX -> ENQ checksum character escaping
- Lower minimum setpoint (for my basement)
- Replace some std::vector use with const strings or sized local buffers (embedded habits die hard)
- Add support for reading out quiet fan mode from RG query